### PR TITLE
Update GT_MetaTileEntity_OilDrillBase.java

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillBase.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_OilDrillBase.java
@@ -87,7 +87,7 @@ public abstract class GT_MetaTileEntity_OilDrillBase extends GT_MetaTileEntity_D
         this.mEfficiencyIncrease = 10000;
         int tier = Math.max(1, GT_Utility.getTier(getMaxInputVoltage()));
         this.mEUt = -3 * (1 << (tier << 1));
-        this.mMaxProgresstime = (workState == STATE_AT_BOTTOM ? (1280 * getRangeInChunks() * getRangeInChunks() / (1 << getMinTier())) : 80) / (1 << tier);
+        this.mMaxProgresstime = (int)(workState == STATE_AT_BOTTOM ? ((1280*(1-(getMinTier()-2)*0.25)) * getRangeInChunks() * getRangeInChunks() / (1 << getMinTier())) : 80) / (1 << tier);
         this.mMaxProgresstime = Math.max(1, this.mMaxProgresstime);
     }
 


### PR DESCRIPTION
Задача https://trello.com/c/bu9yh6Aw/63-%D0%B1%D0%B0%D0%BB%D0%B0%D0%BD%D1%81-oil-drilling-rig
Изначально качалки тратят на чанк соответственно: 4с , 1с, 0,25с
Из задачи нужно 75 и 50 процентов для Т2 и Т3:
4/4*0,75 и 4 * 0,25* 0,5 , получим 0,75 и 0,125
После возвращаем время для 9 и 36 чанков:
0,75 * 9=6,75с  и 0,125 * 36=4,5с
Функция ИНТ, округлит до 6с и 4с
Что и имеем на панели НК:
https://media.discordapp.net/attachments/261093545652256778/697802390845390928/2020-04-09_19.37.08.png