### PR TITLE
Отключение интеграции с Тгрегворксом.

### DIFF
--- a/src/main/java/gregtech/loaders/materialprocessing/ProcessingModSupport.java
+++ b/src/main/java/gregtech/loaders/materialprocessing/ProcessingModSupport.java
@@ -7,17 +7,17 @@ import gregtech.api.enums.OrePrefixes;
 
 public class ProcessingModSupport implements gregtech.api.interfaces.IMaterialHandler {
     public static boolean aTGregSupport = Loader.isModLoaded("TGregworks");
-    public static boolean aEnablePFAAMats = Loader.isModLoaded("PFAAGeologica") || aTGregSupport;
-    public static boolean aEnableUBCMats = Loader.isModLoaded("UndergroundBiomes") || aTGregSupport;
-    public static boolean aEnableThaumcraftMats = Loader.isModLoaded("Thaumcraft") || aTGregSupport;
-    public static boolean aEnableRotaryCraftMats = Loader.isModLoaded("RotaryCraft") || aTGregSupport;
-    public static boolean aEnableThermalFoundationMats = Loader.isModLoaded("ThermalFoundation") || aTGregSupport;
-    public static boolean aEnableEnderIOMats = Loader.isModLoaded("EnderIO") || aTGregSupport;
-    public static boolean aEnableRailcraftMats = Loader.isModLoaded(GT_Values.MOD_ID_RC) || aTGregSupport;
-    public static boolean aEnableGCMarsMats = Loader.isModLoaded("GalacticraftMars") || aTGregSupport;
-    public static boolean aEnableTwilightMats = Loader.isModLoaded(GT_Values.MOD_ID_TF) || aTGregSupport;
-    public static boolean aEnableMetallurgyMats = Loader.isModLoaded("Metallurgy") || aTGregSupport;
-    public static boolean aEnableIHLMats = Loader.isModLoaded("ihl") || aTGregSupport;
+    public static boolean aEnablePFAAMats = Loader.isModLoaded("PFAAGeologica");
+    public static boolean aEnableUBCMats = Loader.isModLoaded("UndergroundBiomes");
+    public static boolean aEnableThaumcraftMats = Loader.isModLoaded("Thaumcraft");
+    public static boolean aEnableRotaryCraftMats = Loader.isModLoaded("RotaryCraft");
+    public static boolean aEnableThermalFoundationMats = Loader.isModLoaded("ThermalFoundation");
+    public static boolean aEnableEnderIOMats = Loader.isModLoaded("EnderIO");
+    public static boolean aEnableRailcraftMats = Loader.isModLoaded(GT_Values.MOD_ID_RC);
+    public static boolean aEnableGCMarsMats = Loader.isModLoaded("GalacticraftMars");
+    public static boolean aEnableTwilightMats = Loader.isModLoaded(GT_Values.MOD_ID_TF);
+    public static boolean aEnableMetallurgyMats = Loader.isModLoaded("Metallurgy");
+    public static boolean aEnableIHLMats = Loader.isModLoaded("ihl");
 
     public ProcessingModSupport() {
         Materials.add(this);


### PR DESCRIPTION
Если в сборке есть тинкер грегворкс, но нет модов в списке с 10 по 20 строку, то всё-равно разлочивается функция и все эти материалы становятся активными и засирают нэи и т.д. Лучше отключить на всякий случай.