### PR TITLE
Pilad patch fix circuit input bus

### DIFF
--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine_GT_Recipe.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_BasicMachine_GT_Recipe.java
@@ -1,6 +1,7 @@
 package gregtech.api.metatileentity.implementations;
 
 import gregtech.api.enums.*;
+import static gregtech.api.util.GT_OreDictUnificator.isItemStackInstanceOf;
 import gregtech.api.gui.GT_Container_BasicMachine;
 import gregtech.api.gui.GT_GUIContainer_BasicMachine;
 import gregtech.api.interfaces.ITexture;
@@ -650,11 +651,17 @@ public class GT_MetaTileEntity_BasicMachine_GT_Recipe extends GT_MetaTileEntity_
             default:
                 int tID = getBaseMetaTileEntity().getMetaTileID();
                 if (tID >= 211 && tID <= 218) {// assemblers IDs
-                    if (GT_OreDictUnificator.isItemStackInstanceOf(aStack, "circuitBasic")) return true; // allow input all LV-circuits for assemblers
-                    if (GT_OreDictUnificator.isItemStackInstanceOf(aStack, "circuitAdvanced")) return true; // allow input all HV-circuits for assemblers
+                    if (isItemStackInstanceOf(aStack, "circuitBasic")) return true; // allow input all LV-circuits for assemblers
+                    if (isItemStackInstanceOf(aStack, "circuitGood")) return true; // allow input all MV-circuits for assemblers
+                    if (isItemStackInstanceOf(aStack, "circuitAdvanced")) return true; // allow input all HV-circuits for assemblers
+                    if (isItemStackInstanceOf(aStack, "circuitData")) return true; // allow input all EV-circuits for assemblers
+                    if (isItemStackInstanceOf(aStack, "circuitElite")) return true; // allow input all IV-circuits for assemblers
+                    if (isItemStackInstanceOf(aStack, "circuitMaster")) return true; // allow input all LuV-circuits for assemblers
+                    if (isItemStackInstanceOf(aStack, "circuitUltimate")) return true; // allow input all ZPM-circuits for assemblers
+                    if (isItemStackInstanceOf(aStack, "circuitSuperconductor")) return true; // allow input all UV-circuits for assemblers
+                    if (isItemStackInstanceOf(aStack, "circuitInfinite")) return true; // allow input all UHV-circuits for assemblers                    
                 }
                 return getRecipeList().containsInput(aStack);
-
         }
     }
 

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Input.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_Input.java
@@ -114,7 +114,7 @@ public class GT_MetaTileEntity_Hatch_Input extends GT_MetaTileEntity_Hatch {
 
     @Override
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
-        return aSide == aBaseMetaTileEntity.getFrontFacing() && aIndex == 0 && (mRecipeMap == null || mRecipeMap.containsInput(aStack) || mRecipeMap.containsInput(GT_Utility.getFluidForFilledItem(aStack, true)));
+        return aSide == aBaseMetaTileEntity.getFrontFacing();
     }
 
     @Override

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_InputBus.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaTileEntity_Hatch_InputBus.java
@@ -167,6 +167,6 @@ public class GT_MetaTileEntity_Hatch_InputBus extends GT_MetaTileEntity_Hatch {
 
     @Override
     public boolean allowPutStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, byte aSide, ItemStack aStack) {
-        return aSide == getBaseMetaTileEntity().getFrontFacing() && (mRecipeMap == null || mRecipeMap.containsInput(aStack));
+        return aSide == aBaseMetaTileEntity.getFrontFacing();
     }
 }


### PR DESCRIPTION
Фиксы загрузки микросхем через ме интерфейсы. фиксы загрузки в инпут басы многоблоков. Проявлялось как отказ принимать предметы в инпут бас у электродоменки через ме интерфейс или предметной трубой любой. Например рецепты пирометаллургии. Не хотела принимать лимониты и карбон.
Фиксы от Алексея.