### PR TITLE
Update GT_MetaTileEntity_Pump.java

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Pump.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_Pump.java
@@ -38,7 +38,7 @@ import static gregtech.api.util.GT_Utility.getFakePlayer;
 public class GT_MetaTileEntity_Pump extends GT_MetaTileEntity_BasicDrillerBase {
 
     static {
-        RADIUS = new int[]{8, 10, 20, 60,180,40,48,56,64,72,80};
+        RADIUS = new int[]{8, 10, 20, 60,180,540,48,56,64,72,80};
         SPEED = new int[]{80, 80, 40, 20, 10, 5,5,2,2,2,2};
         ENERGY = new int[]{8, 4, 16, 64, 256, 1024, 2048 ,32768,131072,524288};
     }


### PR DESCRIPTION
У IV помпы радиус был меньше предыдущего тира. 180 * 3 = 540