### PR TITLE
Update GT_Loader_MetaTileEntities.java

### DIFF
--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -312,11 +312,11 @@ public class GT_Loader_MetaTileEntities implements Runnable {
         GT_ModHandler.addCraftingRecipe(ItemList.Quantum_Tank_EV.get(1L, new Object[0]), bitsd, new Object[]{"DGD", aTextPlateMotor, "DPD", 'M', ItemList.Hull_EV, 'G', ItemList.Field_Generator_EV, 'D', OrePrefixes.circuit.get(Materials.Master), 'P', OrePrefixes.plate.get(Materials.Europium)});
         GT_ModHandler.addCraftingRecipe(ItemList.Quantum_Tank_IV.get(1L, new Object[0]), bitsd, new Object[]{"DGD", aTextPlateMotor, "DPD", 'M', ItemList.Hull_IV, 'G', ItemList.Field_Generator_IV, 'D', OrePrefixes.circuit.get(Materials.Ultimate), 'P', OrePrefixes.plate.get(Materials.Americium)});
 
-        ItemList.Quantum_Chest_LV.set(new GT_MetaTileEntity_QuantumChest(125, "quantum.chest.tier.01", "Quantum Chest I", 1).getStackForm(1L));
-        ItemList.Quantum_Chest_MV.set(new GT_MetaTileEntity_QuantumChest(126, "quantum.chest.tier.02", "Quantum Chest II", 2).getStackForm(1L));
-        ItemList.Quantum_Chest_HV.set(new GT_MetaTileEntity_QuantumChest(127, "quantum.chest.tier.03", "Quantum Chest III", 3).getStackForm(1L));
-        ItemList.Quantum_Chest_EV.set(new GT_MetaTileEntity_QuantumChest(128, "quantum.chest.tier.04", "Quantum Chest IV", 4).getStackForm(1L));
-        ItemList.Quantum_Chest_IV.set(new GT_MetaTileEntity_QuantumChest(129, "quantum.chest.tier.05", "Quantum Chest V", 5).getStackForm(1L));
+        ItemList.Quantum_Chest_LV.set(new GT_MetaTileEntity_QuantumChest(125, "quantum.chest.tier.01", "Quantum Chest I", 6).getStackForm(1L));
+        ItemList.Quantum_Chest_MV.set(new GT_MetaTileEntity_QuantumChest(126, "quantum.chest.tier.02", "Quantum Chest II", 7).getStackForm(1L));
+        ItemList.Quantum_Chest_HV.set(new GT_MetaTileEntity_QuantumChest(127, "quantum.chest.tier.03", "Quantum Chest III", 8).getStackForm(1L));
+        ItemList.Quantum_Chest_EV.set(new GT_MetaTileEntity_QuantumChest(128, "quantum.chest.tier.04", "Quantum Chest IV", 9).getStackForm(1L));
+        ItemList.Quantum_Chest_IV.set(new GT_MetaTileEntity_QuantumChest(129, "quantum.chest.tier.05", "Quantum Chest V", 10).getStackForm(1L));
 
         GT_ModHandler.addCraftingRecipe(ItemList.Quantum_Chest_LV.get(1L, new Object[0]), bitsd, new Object[]{"DPD", aTextPlateMotor, "DGD", 'M', ItemList.Hull_LV, 'G', ItemList.Field_Generator_LV, 'D', OrePrefixes.circuit.get(Materials.Advanced), 'P', OrePrefixes.plate.get(Materials.StainlessSteel)});
         GT_ModHandler.addCraftingRecipe(ItemList.Quantum_Chest_MV.get(1L, new Object[0]), bitsd, new Object[]{"DPD", aTextPlateMotor, "DGD", 'M', ItemList.Hull_MV, 'G', ItemList.Field_Generator_MV, 'D', OrePrefixes.circuit.get(Materials.Data), 'P', OrePrefixes.plate.get(Materials.Titanium)});


### PR DESCRIPTION
Раньше пятый квантовый сундук имел обьём из 10 кейса. А сейчас прописали 5 кейс. Вернул это значение.
https://media.discordapp.net/attachments/251639296946208768/788113001068494868/unknown.png