### PR TITLE
FixRecipesAdjTransformersIV-MAX

### DIFF
--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -2835,27 +2835,32 @@ if(Loader.isModLoaded("Railcraft")){
                 ItemList.Transformer_HV_MV.get(2L),
                 ItemList.Transformer_EV_HV.get(1L),
                 ItemList.Cover_Screen.get(1L)}, OrePrefixes.circuit.get(Materials.Data), 4, GT_Values.NF, ItemList.Machine_DigitalTransformer_EV.get(1L), 50, 1920);
+				
         GT_Values.RA.addAssemblerRecipe(new ItemStack[]{
                 ItemList.Transformer_IV_EV.get(1L),
-                ItemList.Machine_DigitalTransformer_EV.get(2L),
-                ItemList.Cover_Screen.get(1L)}, OrePrefixes.circuit.get(Materials.Elite), 4, GT_Values.NF, ItemList.Machine_DigitalTransformer_IV.get(1L), 50, 1920);
+                ItemList.Machine_DigitalTransformer_EV.get(2L)
+                }, OrePrefixes.circuit.get(Materials.Elite), 2, GT_Values.NF, ItemList.Machine_DigitalTransformer_IV.get(1L), 50, 1920);
+				
         GT_Values.RA.addAssemblerRecipe(new ItemStack[]{
                 ItemList.Transformer_LuV_IV.get(1L),
-                ItemList.Machine_DigitalTransformer_IV.get(2L),
-                ItemList.Cover_Screen.get(1L)}, OrePrefixes.circuit.get(Materials.Master), 4, GT_Values.NF, ItemList.Machine_DigitalTransformer_LuV.get(1L), 50, 1920);
+                ItemList.Machine_DigitalTransformer_IV.get(2L)
+                }, OrePrefixes.circuit.get(Materials.Master), 2, GT_Values.NF, ItemList.Machine_DigitalTransformer_LuV.get(1L), 50, 1920);
+				
         GT_Values.RA.addAssemblerRecipe(new ItemStack[]{
                 ItemList.Transformer_ZPM_LuV.get(1L),
-                ItemList.Machine_DigitalTransformer_LuV.get(2L),
-                ItemList.Cover_Screen.get(1L)}, OrePrefixes.circuit.get(Materials.Ultimate), 4, GT_Values.NF, ItemList.Machine_DigitalTransformer_ZPM.get(1L), 50, 1920);
+                ItemList.Machine_DigitalTransformer_LuV.get(2L)
+                }, OrePrefixes.circuit.get(Materials.Ultimate), 2, GT_Values.NF, ItemList.Machine_DigitalTransformer_ZPM.get(1L), 50, 1920);
+				
         GT_Values.RA.addAssemblerRecipe(new ItemStack[]{
                 ItemList.Transformer_UV_ZPM.get(1L),
-                ItemList.Machine_DigitalTransformer_ZPM.get(2L),
-                ItemList.Cover_Screen.get(1L)}, OrePrefixes.circuit.get(Materials.Superconductor), 4, GT_Values.NF, ItemList.Machine_DigitalTransformer_UV.get(1L), 50, 1920);
+                ItemList.Machine_DigitalTransformer_ZPM.get(2L)
+                }, OrePrefixes.circuit.get(Materials.Superconductor), 2, GT_Values.NF, ItemList.Machine_DigitalTransformer_UV.get(1L), 50, 1920);
+				
         GT_Values.RA.addAssemblerRecipe(new ItemStack[]{
                 ItemList.Transformer_MAX_UV.get(1L),
-                ItemList.Machine_DigitalTransformer_UV.get(2L),
-                ItemList.Cover_Screen.get(1L)}, OrePrefixes.circuit.get(Materials.Infinite), 4, GT_Values.NF, ItemList.Machine_DigitalTransformer_MAX.get(1L), 50, 1920);
-
+                ItemList.Machine_DigitalTransformer_UV.get(2L)
+                }, OrePrefixes.circuit.get(Materials.Infinite), 2, GT_Values.NF, ItemList.Machine_DigitalTransformer_MAX.get(1L), 50, 1920);
+				
         GT_Values.RA.addDisassemblerRecipe(
                 ItemList.Machine_DigitalTransformer_EV.get(1), new ItemStack[]{
                 ItemList.Transformer_LV_ULV.get(8L),
@@ -2865,40 +2870,40 @@ if(Loader.isModLoaded("Railcraft")){
                 ItemList.Cover_Screen.get(1L), 
                 ItemList.Circuit_Nanocomputer.get(4L)
                 }, 2400, 16);
+				
         GT_Values.RA.addDisassemblerRecipe(
                 ItemList.Machine_DigitalTransformer_IV.get(1), new ItemStack[]{
                 ItemList.Transformer_IV_EV.get(1L),
                 ItemList.Machine_DigitalTransformer_EV.get(2L),
-                ItemList.Cover_Screen.get(1L), 
-                ItemList.Circuit_Quantumcomputer.get(4L)
-                }, 2400, 16);                
+                ItemList.Circuit_Quantumcomputer.get(2L)
+                }, 2400, 16); 
+				
         GT_Values.RA.addDisassemblerRecipe(
                 ItemList.Machine_DigitalTransformer_LuV.get(1), new ItemStack[]{
                 ItemList.Transformer_LuV_IV.get(1L),
                 ItemList.Machine_DigitalTransformer_IV.get(2L),
-                ItemList.Cover_Screen.get(1L), 
-                ItemList.Circuit_Crystalcomputer.get(4L)
+                ItemList.Circuit_Crystalcomputer.get(2L)
                 }, 2400, 16);
+				
         GT_Values.RA.addDisassemblerRecipe(
                 ItemList.Machine_DigitalTransformer_ZPM.get(1), new ItemStack[]{
                 ItemList.Transformer_ZPM_LuV.get(1L),
                 ItemList.Machine_DigitalTransformer_LuV.get(2L),
-                ItemList.Cover_Screen.get(1L), 
-                ItemList.Circuit_Wetwarecomputer.get(4L)
-                }, 2400, 16);                
+                ItemList.Circuit_Wetwarecomputer.get(2L)
+                }, 2400, 16);   
+				
         GT_Values.RA.addDisassemblerRecipe(
                 ItemList.Machine_DigitalTransformer_UV.get(1), new ItemStack[]{
                 ItemList.Transformer_UV_ZPM.get(1L),
                 ItemList.Machine_DigitalTransformer_ZPM.get(2L),
-                ItemList.Cover_Screen.get(1L), 
-                ItemList.Circuit_Wetwaresupercomputer.get(4L)
+                ItemList.Circuit_Wetwaresupercomputer.get(2L)
                 }, 2400, 16);
+				
         GT_Values.RA.addDisassemblerRecipe(
                 ItemList.Machine_DigitalTransformer_MAX.get(1), new ItemStack[]{
                 ItemList.Transformer_MAX_UV.get(1L),
                 ItemList.Machine_DigitalTransformer_UV.get(2L),
-                ItemList.Cover_Screen.get(1L), 
-                ItemList.Circuit_Wetwaremainframe.get(4L)
+                ItemList.Circuit_Wetwaremainframe.get(2L)
                 }, 2400, 16);
 
         GT_Values.RA.addReplicatorRecipe(GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 1), GT_OreDictUnificator.get(OrePrefixes.dust, Materials.NetherStar, 1),  true, 13824000, 32, 10000, 6912000, 32);

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -2838,27 +2838,27 @@ if(Loader.isModLoaded("Railcraft")){
 				
         GT_Values.RA.addAssemblerRecipe(new ItemStack[]{
                 ItemList.Transformer_IV_EV.get(1L),
-                ItemList.Machine_DigitalTransformer_EV.get(2L)
+                ItemList.Machine_DigitalTransformer_EV.get(1L)
                 }, OrePrefixes.circuit.get(Materials.Elite), 2, GT_Values.NF, ItemList.Machine_DigitalTransformer_IV.get(1L), 50, 1920);
 				
         GT_Values.RA.addAssemblerRecipe(new ItemStack[]{
                 ItemList.Transformer_LuV_IV.get(1L),
-                ItemList.Machine_DigitalTransformer_IV.get(2L)
+                ItemList.Machine_DigitalTransformer_IV.get(1L)
                 }, OrePrefixes.circuit.get(Materials.Master), 2, GT_Values.NF, ItemList.Machine_DigitalTransformer_LuV.get(1L), 50, 1920);
 				
         GT_Values.RA.addAssemblerRecipe(new ItemStack[]{
                 ItemList.Transformer_ZPM_LuV.get(1L),
-                ItemList.Machine_DigitalTransformer_LuV.get(2L)
+                ItemList.Machine_DigitalTransformer_LuV.get(1L)
                 }, OrePrefixes.circuit.get(Materials.Ultimate), 2, GT_Values.NF, ItemList.Machine_DigitalTransformer_ZPM.get(1L), 50, 1920);
 				
         GT_Values.RA.addAssemblerRecipe(new ItemStack[]{
                 ItemList.Transformer_UV_ZPM.get(1L),
-                ItemList.Machine_DigitalTransformer_ZPM.get(2L)
+                ItemList.Machine_DigitalTransformer_ZPM.get(1L)
                 }, OrePrefixes.circuit.get(Materials.Superconductor), 2, GT_Values.NF, ItemList.Machine_DigitalTransformer_UV.get(1L), 50, 1920);
 				
         GT_Values.RA.addAssemblerRecipe(new ItemStack[]{
                 ItemList.Transformer_MAX_UV.get(1L),
-                ItemList.Machine_DigitalTransformer_UV.get(2L)
+                ItemList.Machine_DigitalTransformer_UV.get(1L)
                 }, OrePrefixes.circuit.get(Materials.Infinite), 2, GT_Values.NF, ItemList.Machine_DigitalTransformer_MAX.get(1L), 50, 1920);
 				
         GT_Values.RA.addDisassemblerRecipe(
@@ -2874,35 +2874,35 @@ if(Loader.isModLoaded("Railcraft")){
         GT_Values.RA.addDisassemblerRecipe(
                 ItemList.Machine_DigitalTransformer_IV.get(1), new ItemStack[]{
                 ItemList.Transformer_IV_EV.get(1L),
-                ItemList.Machine_DigitalTransformer_EV.get(2L),
+                ItemList.Machine_DigitalTransformer_EV.get(1L),
                 ItemList.Circuit_Quantumcomputer.get(2L)
                 }, 2400, 16); 
 				
         GT_Values.RA.addDisassemblerRecipe(
                 ItemList.Machine_DigitalTransformer_LuV.get(1), new ItemStack[]{
                 ItemList.Transformer_LuV_IV.get(1L),
-                ItemList.Machine_DigitalTransformer_IV.get(2L),
+                ItemList.Machine_DigitalTransformer_IV.get(1L),
                 ItemList.Circuit_Crystalcomputer.get(2L)
                 }, 2400, 16);
 				
         GT_Values.RA.addDisassemblerRecipe(
                 ItemList.Machine_DigitalTransformer_ZPM.get(1), new ItemStack[]{
                 ItemList.Transformer_ZPM_LuV.get(1L),
-                ItemList.Machine_DigitalTransformer_LuV.get(2L),
+                ItemList.Machine_DigitalTransformer_LuV.get(1L),
                 ItemList.Circuit_Wetwarecomputer.get(2L)
                 }, 2400, 16);   
 				
         GT_Values.RA.addDisassemblerRecipe(
                 ItemList.Machine_DigitalTransformer_UV.get(1), new ItemStack[]{
                 ItemList.Transformer_UV_ZPM.get(1L),
-                ItemList.Machine_DigitalTransformer_ZPM.get(2L),
+                ItemList.Machine_DigitalTransformer_ZPM.get(1L),
                 ItemList.Circuit_Wetwaresupercomputer.get(2L)
                 }, 2400, 16);
 				
         GT_Values.RA.addDisassemblerRecipe(
                 ItemList.Machine_DigitalTransformer_MAX.get(1), new ItemStack[]{
                 ItemList.Transformer_MAX_UV.get(1L),
-                ItemList.Machine_DigitalTransformer_UV.get(2L),
+                ItemList.Machine_DigitalTransformer_UV.get(1L),
                 ItemList.Circuit_Wetwaremainframe.get(2L)
                 }, 2400, 16);
 


### PR DESCRIPTION
Sapient: Еще задачка по рецептам:
Рецепты Adjustable Transformer c IV до UV тира привести к виду: Обычный трансформатор предыдущего тира + настраиваемый трансформатор предыдущего тира + 2 микрухи текущего тира. То есть из рецептов выкидываются Computer monitor (хватит одного в рецепте на EV тире) и вдвое уменьшается кол-во настраиваемых трансов и микрух.

21:06] Pilad: то есть с ИВ и далее снижаем количество микрух до двух, они так и есть этого тира, то есть ИВ(изменено)
[21:07] Pilad: и трансы так же соответствует
[21:07] Pilad: то есть задача сводится уменьшить количество микрух с 4 до 2 и убрать мониторы из рецептов