### PR TITLE
Repellator event handler reworked.

### DIFF
--- a/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
+++ b/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
@@ -5,6 +5,9 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import gregtech.api.metatileentity.BaseMetaTileEntity;
 import gregtech.common.tileentities.machines.basic.GT_MetaTileEntity_MonsterRepellent;
 import net.minecraft.entity.EnumCreatureType;
+import net.minecraft.entity.monster.EntityPigZombie;
+import net.minecraft.entity.passive.EntityOcelot;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent.CheckSpawn;
@@ -22,10 +25,13 @@ public class GT_SpawnEventHandler {
 
     @SubscribeEvent
     public void denyMobSpawn(CheckSpawn event) {
-        if (event.getResult() == Event.Result.ALLOW) {
+        if (event.getResult() == Event.Result.ALLOW || (event.entityLiving instanceof EntityPlayer)) {
             return;
         }
-        if (event.entityLiving.isCreatureType(EnumCreatureType.monster, false)) {
+        if (event.entityLiving.isCreatureType(EnumCreatureType.monster, false) ||
+                (event.entityLiving instanceof EntityPigZombie) ||
+                (event.entityLiving instanceof EntityOcelot)
+            ) {
             for (int[] rep : mobReps) {
                 if (rep[3] == event.entity.worldObj.provider.dimensionId) {
                     TileEntity tTile = event.entity.worldObj.getTileEntity(rep[0], rep[1], rep[2]);
@@ -34,7 +40,9 @@ public class GT_SpawnEventHandler {
                         double dx = rep[0] + 0.5F - event.entity.posX;
                         double dy = rep[1] + 0.5F - event.entity.posY;
                         double dz = rep[2] + 0.5F - event.entity.posZ;
-                        if ((dx * dx + dz * dz + dy * dy) <= Math.pow(r, 2)) {
+                        //Original - sphere: (dx * dx + dz * dz + dy * dy) <= Math.pow(r, 2)
+                        //New - cube: (Math.abs(dx) <= r && Math.abs(dz) <= r && Math.abs(dy) <= r)
+                        if (Math.abs(dx) <= r && Math.abs(dz) <= r && Math.abs(dy) <= r) {
                             event.setResult(Event.Result.DENY);
                         }
                     }

--- a/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
+++ b/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
@@ -28,22 +28,29 @@ public class GT_SpawnEventHandler {
         if (event.getResult() == Event.Result.ALLOW || (event.entityLiving instanceof EntityPlayer)) {
             return;
         }
-        if (event.entityLiving.isCreatureType(EnumCreatureType.monster, false) ||
-                (event.entityLiving instanceof EntityPigZombie) ||
-                (event.entityLiving instanceof EntityOcelot)
-            ) {
+        if (event.entityLiving.isCreatureType(EnumCreatureType.monster, false)
+            || event.entityLiving instanceof EntityPigZombie || event.entityLiving instanceof EntityOcelot
+            )
+        {
+            boolean spawnIsNeutral = (event.entityLiving instanceof EntityPigZombie || event.entityLiving instanceof EntityOcelot);
             for (int[] rep : mobReps) {
                 if (rep[3] == event.entity.worldObj.provider.dimensionId) {
                     TileEntity tTile = event.entity.worldObj.getTileEntity(rep[0], rep[1], rep[2]);
                     if (tTile instanceof BaseMetaTileEntity && ((BaseMetaTileEntity) tTile).getMetaTileEntity() instanceof GT_MetaTileEntity_MonsterRepellent) {
                         int r = ((GT_MetaTileEntity_MonsterRepellent) ((BaseMetaTileEntity) tTile).getMetaTileEntity()).mRange;
+                        boolean neutralsAllowed =
+                                ((GT_MetaTileEntity_MonsterRepellent) ((BaseMetaTileEntity) tTile).getMetaTileEntity()).mNeutralsAllowed;
                         double dx = rep[0] + 0.5F - event.entity.posX;
                         double dy = rep[1] + 0.5F - event.entity.posY;
                         double dz = rep[2] + 0.5F - event.entity.posZ;
                         //Original - sphere: (dx * dx + dz * dz + dy * dy) <= Math.pow(r, 2)
                         //New - cube: (Math.abs(dx) <= r && Math.abs(dz) <= r && Math.abs(dy) <= r)
                         if (Math.abs(dx) <= r && Math.abs(dz) <= r && Math.abs(dy) <= r) {
-                            event.setResult(Event.Result.DENY);
+                            if ((!neutralsAllowed && spawnIsNeutral) || (!spawnIsNeutral))
+                            {
+                                event.setResult(Event.Result.DENY);
+                                break;
+                            }
                         }
                     }
                 }

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_MonsterRepellent.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_MonsterRepellent.java
@@ -12,6 +12,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.entity.player.EntityPlayer;
 
+import java.util.Arrays;
+
 import static gregtech.api.enums.GT_Values.V;
 
 public class GT_MetaTileEntity_MonsterRepellent extends GT_MetaTileEntity_TieredMachineBlock {
@@ -45,7 +47,8 @@ public class GT_MetaTileEntity_MonsterRepellent extends GT_MetaTileEntity_Tiered
     public void onPostTick(IGregTechTileEntity aBaseMetaTileEntity, long aTimer) {
         if (aBaseMetaTileEntity.isAllowedToWork() && aBaseMetaTileEntity.isServerSide()) {
             int[] tCoords = new int[]{aBaseMetaTileEntity.getXCoord(), aBaseMetaTileEntity.getYCoord(), aBaseMetaTileEntity.getZCoord(), aBaseMetaTileEntity.getWorld().provider.dimensionId};
-            if ((aTimer % 600 == 0) && !GT_SpawnEventHandler.mobReps.contains(tCoords)) {
+            if ((aTimer % 600 == 0) && !GT_SpawnEventHandler.mobReps.stream().anyMatch(c -> Arrays.equals(c, tCoords)))
+            {
                 GT_SpawnEventHandler.mobReps.add(tCoords);
             }
             if (aBaseMetaTileEntity.isUniversalEnergyStored(getMinimumStoredEU()) && aBaseMetaTileEntity.decreaseStoredEnergyUnits(1 << (this.mTier * 2), false)) {
@@ -59,19 +62,21 @@ public class GT_MetaTileEntity_MonsterRepellent extends GT_MetaTileEntity_Tiered
     @Override
     public void onFirstTick(IGregTechTileEntity aBaseMetaTileEntity) {
         int[] tCoords = new int[]{aBaseMetaTileEntity.getXCoord(), aBaseMetaTileEntity.getYCoord(), aBaseMetaTileEntity.getZCoord(), aBaseMetaTileEntity.getWorld().provider.dimensionId};
-        GT_SpawnEventHandler.mobReps.add(tCoords);
+        if (GT_SpawnEventHandler.mobReps != null && !GT_SpawnEventHandler.mobReps.stream().anyMatch(c -> Arrays.equals(c, tCoords))){
+            GT_SpawnEventHandler.mobReps.add(tCoords);
+        }
     }
 
     @Override
     public void onRemoval() {
         int[] tCoords = new int[]{this.getBaseMetaTileEntity().getXCoord(), this.getBaseMetaTileEntity().getYCoord(), this.getBaseMetaTileEntity().getZCoord(), this.getBaseMetaTileEntity().getWorld().provider.dimensionId};
-        GT_SpawnEventHandler.mobReps.remove(tCoords);
+        GT_SpawnEventHandler.mobReps.removeIf(seh -> Arrays.equals(seh,tCoords));
     }
 
     @Override
     public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
             mNeutralsAllowed = !mNeutralsAllowed;
-            GT_Utility.sendChatToPlayer(aPlayer, mNeutralsAllowed ? trans("095","Prevents spawn of hostile creatures") : trans("096","Prevents spawn of hostile creatures, pig zombies and ocelots"));
+            GT_Utility.sendChatToPlayer(aPlayer, mNeutralsAllowed ? trans("217","Prevents spawn of hostile creatures") : trans("218","Prevents spawn of hostile creatures, pig zombies and ocelots"));
     }
 
 

--- a/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_MonsterRepellent.java
+++ b/src/main/java/gregtech/common/tileentities/machines/basic/GT_MetaTileEntity_MonsterRepellent.java
@@ -7,6 +7,7 @@ import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.api.metatileentity.implementations.GT_MetaTileEntity_TieredMachineBlock;
 import gregtech.api.objects.GT_RenderedTexture;
 import gregtech.api.util.GT_SpawnEventHandler;
+import gregtech.api.util.GT_Utility;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.entity.player.EntityPlayer;
@@ -16,6 +17,8 @@ import static gregtech.api.enums.GT_Values.V;
 public class GT_MetaTileEntity_MonsterRepellent extends GT_MetaTileEntity_TieredMachineBlock {
 
     public int mRange = 16;
+
+    public boolean mNeutralsAllowed = true;
 
     public GT_MetaTileEntity_MonsterRepellent(int aID, String aName, String aNameRegional, int aTier) {
         super(aID, aName, aNameRegional, aTier, 0, "Repels nasty Creatures. Range: " + (4 + (12 * aTier)) + " unpowered / " + (16 + (48 * aTier)) + " powered");
@@ -64,6 +67,13 @@ public class GT_MetaTileEntity_MonsterRepellent extends GT_MetaTileEntity_Tiered
         int[] tCoords = new int[]{this.getBaseMetaTileEntity().getXCoord(), this.getBaseMetaTileEntity().getYCoord(), this.getBaseMetaTileEntity().getZCoord(), this.getBaseMetaTileEntity().getWorld().provider.dimensionId};
         GT_SpawnEventHandler.mobReps.remove(tCoords);
     }
+
+    @Override
+    public void onScrewdriverRightClick(byte aSide, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+            mNeutralsAllowed = !mNeutralsAllowed;
+            GT_Utility.sendChatToPlayer(aPlayer, mNeutralsAllowed ? trans("095","Prevents spawn of hostile creatures") : trans("096","Prevents spawn of hostile creatures, pig zombies and ocelots"));
+    }
+
 
     @Override
     public boolean isAccessAllowed(EntityPlayer aPlayer) {
@@ -132,9 +142,11 @@ public class GT_MetaTileEntity_MonsterRepellent extends GT_MetaTileEntity_Tiered
 
     @Override
     public void saveNBTData(NBTTagCompound aNBT) {
+        aNBT.setBoolean("neutralsAllowed", mNeutralsAllowed);
     }
 
     @Override
     public void loadNBTData(NBTTagCompound aNBT) {
+        mNeutralsAllowed = aNBT.getBoolean("neutralsAllowed");
     }
 }


### PR DESCRIPTION
Переработан отпугиватель монстров(Monster repellator)
Область работы изменена с шара с указанным радиусом на куб(с репеллатором по центру). Заявленные ограничения по расстоянию оставлены без изменений.
Добавлены два режима(переключаются отвёрткой):
1 - Отменяет спаун только враждебных мобов(по умолчанию)
2 - Отменяет спаун враждебных мобов, свинозомби и оцелотов
Добавлена локализация для сообщений при клике отвёрткой:
S:Interaction_DESCRIPTION_Index_217 - для первого режима
S:Interaction_DESCRIPTION_Index_218 - для второго
Оптимизированы обработчики спауна у репеллаторов немного, должны работать чуть быстрее.
Исправлены баги, из-за которых плодились дубли обработчиков, при длительной работе сервера могло вызывать замедление и избыточное потребление памяти. 

Signed-off-by: ShoGUN <shogun.kub@gmail.com>