### PR TITLE
Add new recipes for IC2 items

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/GT_IndustialCraftRecipesLoader.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/GT_IndustialCraftRecipesLoader.java
@@ -23,6 +23,10 @@ public class GT_IndustialCraftRecipesLoader implements Runnable {
 
         GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getIC2Item("carbonFiber", 1L));
 
+        GT_ModHandler.addCompressionRecipe(GT_ModHandler.getModItem("IC2", "itemPartCarbonMesh", 1L), GT_ModHandler.getModItem("IC2", "itemPartCarbonPlate", 1L));
+        GT_ModHandler.addPulverisationRecipe(GT_ModHandler.getModItem("IC2", "itemFuelPlantBall", 1L), GT_ModHandler.getModItem("IC2", "itemBiochaff", 1L));
+        GT_ModHandler.addPulverisationRecipe(GT_ModHandler.getModItem("IC2", "blockMiningPipe", 1L), GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.Steel, 2L));
+
         if (GT_Mod.gregtechproxy.mDisableIC2Cables) {
             GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getIC2Item("copperCableItem", 1L));
             GT_ModHandler.removeRecipeByOutput(GT_ModHandler.getIC2Item("insulatedCopperCableItem", 1L));


### PR DESCRIPTION
При добавлении ангелики пропадают рецепты биочафа и карбонплэйта, первые две строки. Можно их так же закоментить теперь в конфиге индастриал крафта в папке ic2. Третья строка это рецепт из скрипта GT_IC2.zs на дробление майнинг пайп в две пыльки из стали. Но скрипт при первом входе не применяет его, думаю из-за того что добавляет в машину иц2 ,а не гречки. Можно теперь удалить строку из скрипта.
<img width="1190" height="111" alt="изображение" src="https://github.com/user-attachments/assets/e38c2c90-1788-4ae5-b20e-37e2d90016fc" />
<img width="602" height="51" alt="изображение" src="https://github.com/user-attachments/assets/9cc9de15-9b30-4763-ba62-25332be53297" />
<img width="499" height="49" alt="изображение" src="https://github.com/user-attachments/assets/2fc65a91-1ff0-4bbf-bb62-888adc72da6f" />
