### PR TITLE
Fix fuel consumption calculation in Diesel Engine

### DIFF
--- a/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DieselEngine.java
+++ b/src/main/java/gregtech/common/tileentities/machines/multi/GT_MetaTileEntity_DieselEngine.java
@@ -93,6 +93,7 @@ public class GT_MetaTileEntity_DieselEngine extends GT_MetaTileEntity_MultiBlock
                     if ((tLiquid = GT_Utility.getFluidForFilledItem(aFuel.getRepresentativeInput(0), true)) != null) { //Create fluidstack from current recipe
                         if (hatchFluid1.isFluidEqual(tLiquid)) { //Has a diesel fluid
                             fuelConsumption = tLiquid.amount = boostEu ? (4096 / aFuel.mSpecialValue) : (2048 / aFuel.mSpecialValue); //Calc fuel consumption
+                            fuelConsumption = tLiquid.amount = Math.max(tLiquid.amount, 1); //fix if fuel callories < 1
                             if(depleteInput(tLiquid)) { //Deplete that amount
                                 boostEu = depleteInput(Materials.Oxygen.getGas(oxygenPerTick));
 


### PR DESCRIPTION
Если калорийность топлива будет высокой и при расчете станет меньше 1, то ставим 1. Иначе генератор не будет потреблять топливо и будет выдавать энергию.